### PR TITLE
test: empty custom-commands override

### DIFF
--- a/test-empty-override.txt
+++ b/test-empty-override.txt
@@ -1,0 +1,1 @@
+# Test empty list override


### PR DESCRIPTION
Testing empty per-repo custom-commands disables global